### PR TITLE
Use `suggest_float` instead of `suggest_loguniform`.

### DIFF
--- a/src/autoxgb/params.py
+++ b/src/autoxgb/params.py
@@ -1,8 +1,8 @@
 def get_params(trial, model_config):
     params = {
         "learning_rate": trial.suggest_float("learning_rate", 1e-2, 0.25, log=True),
-        "reg_lambda": trial.suggest_loguniform("reg_lambda", 1e-8, 100.0),
-        "reg_alpha": trial.suggest_loguniform("reg_alpha", 1e-8, 100.0),
+        "reg_lambda": trial.suggest_float("reg_lambda", 1e-8, 100.0, log=True),
+        "reg_alpha": trial.suggest_float("reg_alpha", 1e-8, 100.0, log=True),
         "subsample": trial.suggest_float("subsample", 0.1, 1.0),
         "colsample_bytree": trial.suggest_float("colsample_bytree", 0.1, 1.0),
         "max_depth": trial.suggest_int("max_depth", 1, 9),


### PR DESCRIPTION
Thank you for your great project!
I just found a point I could contribute although I'm not sure if this repository receives pull requests.
Please feel free to close the PR if you don't need it.

## Motivation

- `Trial.suggest_loguniform` will be deprecated according to https://github.com/optuna/optuna/issues/2939.
- It recommends `Trial.suggest_float(..., log=True)` instead of it.

## Changes

- This PR simply replaces `Trial.suggest_loguniform` with `Trial.suggest_float`.